### PR TITLE
Replace TUNA w/ BFSU

### DIFF
--- a/user_overrides.yml
+++ b/user_overrides.yml
@@ -42,22 +42,22 @@ bootloader_http_enabled: true
 
 release_overrides:
   almalinux:
-    mirror: https://mirrors.tuna.tsinghua.edu.cn
+    mirror: https://mirrors.bfsu.edu.cn
   alpinelinux:
-    mirror: https://mirrors.tuna.tsinghua.edu.cn
+    mirror: https://mirrors.bfsu.edu.cn
   archlinux:
-    mirror: https://mirrors.tuna.tsinghua.edu.cn
+    mirror: https://mirrors.bfsu.edu.cn
   centos:
     mirror: https://mirrors.aliyun.com
   debian:
     mirror: https://mirrors.aliyun.com
     archive_mirror: https://mirrors.aliyun.com/debian-archive
   devuan:
-    mirror: https://mirrors.tuna.tsinghua.edu.cn
+    mirror: https://mirrors.bfsu.edu.cn
   fedora:
-    mirror: https://mirrors.tuna.tsinghua.edu.cn
+    mirror: https://mirrors.bfsu.edu.cn
   kali:
-    mirror: https://mirrors.tuna.tsinghua.edu.cn
+    mirror: https://mirrors.bfsu.edu.cn
   mageia:
     mirror: https://mirrors.bfsu.edu.cn
   openEuler:
@@ -74,7 +74,7 @@ release_overrides:
   tinycore:
     mirror: https://mirrors.aliyun.com/tinycorelinux
   ubuntu:
-    mirror: https://mirrors.tuna.tsinghua.edu.cn
+    mirror: https://mirrors.bfsu.edu.cn
     archive_mirror: https://mirrors.aliyun.com/oldubuntu-releases
 
 # set utilitiesefi_overrides from standard netboot.xyz defaults for EFI utilities


### PR DESCRIPTION
The TUNA mirror has been overloaded:

https://mirrors.tuna.tsinghua.edu.cn/status/#server-status

<img width="1384" alt="image" src="https://github.com/user-attachments/assets/d02b78ee-c9d7-4ab7-b6a9-c239fe94f977">

And there is the BFSU mirror (https://mirrors.bfsu.edu.cn), powered by BFSU's infrastructure and maintained by the TUNA, and is underloaded:

https://mirrors.bfsu.edu.cn/status/#server-status

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/a8375997-c636-4404-a6fc-7c3a64bab9ad">

The PR replaces the TUNA mirror with the BFSU mirror.